### PR TITLE
feat: run automated tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: 'Test'
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      # This step should prefer the cached dependencies and restore node_modules
+      - name: Install dependencies
+        run: yarn --immutable
+
+      - name: Run tests for all projects
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "server:dev": "yarn workspace @project/server start",
     "server:generate": "yarn workspace @project/server prisma generate",
     "storybook": "yarn workspace @project/ui storybook",
+    "test": "yarn workspaces foreach run test",
     "web:dev": "yarn workspace @project/web dev",
     "web:generate": "yarn workspace @project/web codegen"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --no-error-on-unmatched-pattern"
+    "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --no-error-on-unmatched-pattern",
+    "test": "echo common: ok"
   },
   "devDependencies": {
     "@project/eslint-config": "^1.0.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "echo eslint-config: ok"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
-    "start": "ts-node-dev src/index.ts"
+    "start": "ts-node-dev src/index.ts",
+    "test": "echo server: ok"
   },
   "private": true,
   "devDependencies": {

--- a/packages/ui/src/stories/__snapshots__/NavLink.stories.storyshot
+++ b/packages/ui/src/stories/__snapshots__/NavLink.stories.storyshot
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Example/NavLink NavLink 1`] = `
+<NavLink
+  href="https://example.com"
+>
+  Example
+</NavLink>
+`;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,8 @@
     "codegen": "graphql-codegen --config codegen.yml",
     "dev": "next",
     "lint": "eslint \"pages/**/*.{js,jsx,ts,tsx}\"",
-    "start": "next start"
+    "start": "next start",
+    "test": "echo web: ok"
   },
   "devDependencies": {
     "@atmina/local-typescript-operations": "^0.4.7",


### PR DESCRIPTION
This PR adds a test GitHub action that runs the test script in all packages. To allow for this, packages without tests had their test script set to simply echo a string.

There are two known warning in the UI package's test run which are already addressed in the storybook repository:

1) https://github.com/storybookjs/storybook/issues/13815 (storyFn is deprecated)
2) https://github.com/storybookjs/storybook/pull/14769 (Jest MDX unexpected token export)